### PR TITLE
Implement the "Static Argument" transformation

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -364,6 +364,7 @@ library
                      , Core.Optimise
                      , Core.Simplify
                      , Core.Occurrence
+                     , Core.Optimise.SAT
                      , Core.Optimise.Reduce
                      , Core.Optimise.Reduce.Base
                      , Core.Optimise.Reduce.Inline

--- a/src/Core/Optimise/SAT.hs
+++ b/src/Core/Optimise/SAT.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
+
+{-
+The "Static Argument" transformation. The idea of the SAT as an
+optimisation is to reduce the number of arguments that must be passed to
+a recursive function, and, subsequently, the argument shuffling noise.
+
+Example:
+
+>  let map @a @b (f : a -> b) (xs : list a -> list b) =
+>    match xs with
+>    | [] -> [] @a
+>    | Cons (x, xs) ->
+>      let x = f x
+>      let xs = map @a @b f xs
+>      Cons (x, xs)
+
+Here, the recursive call to map is always made with the same arguments
+@a, @b, f and xs. We call these the "static arguments" of map.
+We can lift them out of the recursive path:
+
+>  let map @a @b (f : a -> b) =
+>     let rec map_sat (xs : list a -> list b) =
+>       let map_shadow @a @b (f : a -> b) (xs : list a -> list b) =
+>         map_sat xs
+>       match xs with
+>       | [] -> [] @a
+>       | Cons (x, xs) ->
+>         let x = f x
+>         let xs = map_shadow @a @b f xs
+>         Cons (x, xs)
+>     map_sat
+
+Then, the shadow can inline:
+
+>  let map @a @b (f : a -> b) =
+>     let rec map_sat (xs : list a -> list b) =
+>       match xs with
+>       | [] -> [] @a
+>       | Cons (x, xs) ->
+>         let x = f x
+>         let xs = map_sat xs
+>         Cons (x, xs)
+>     map_sat
+
+Now the only parameter we have to pass in the recursive loop is 'xs'.
+-}
+module Core.Optimise.SAT (staticArgsPass) where
+
+import Control.Monad.Namey
+import Control.Lens
+
+import qualified Data.VarMap as VarMap
+
+import Core.Lower.Basic
+import Core.Optimise
+
+import qualified Data.List.NonEmpty as NE
+import Data.Semigroup
+import Data.List
+
+-- | Do the static argument transformation on a whole program.
+staticArgsPass :: (MonadNamey m, IsVar a) => [Stmt a] -> m [Stmt a]
+staticArgsPass = traverse staticArg_stmt
+
+staticArg_stmt :: (MonadNamey m, IsVar a) => Stmt a -> m (Stmt a)
+staticArg_stmt (StmtLet (Many xs))
+  | [(var, tau, lam)] <- xs, manifestLams tau lam >= 2 = do
+      binding <- doStaticArgs var tau lam
+      pure $ StmtLet (Many [binding])
+  | otherwise = do
+      xs' <- traverse (_3 %%~ staticArg_expr) xs
+      pure $ StmtLet (Many xs')
+
+staticArg_stmt (StmtLet (One (var, tau, binding))) = do
+  exp <- staticArg_expr binding
+  pure $ StmtLet (One (var, tau, exp))
+
+staticArg_stmt x@Foreign{} = pure x
+staticArg_stmt x@Type{} = pure x
+
+staticArg_expr :: (MonadNamey m, IsVar a) => Term a -> m (Term a)
+staticArg_expr (Let (Many xs) tail)
+  | [(var, tau, lam)] <- xs, manifestLams tau lam >= 2 = do
+      binding <- doStaticArgs var tau lam
+      Let (Many [binding]) <$>
+        staticArg_expr tail
+  | otherwise = do
+    xs' <- traverse (_3 %%~ staticArg_expr) xs
+    Let (Many xs') <$> staticArg_expr tail
+
+staticArg_expr (Let (One (var, tau, binding)) tail) = do
+  binding <- staticArg_expr binding
+  Let (One (var, tau, binding)) <$>
+    staticArg_expr tail
+
+staticArg_expr (Match atm arms) = Match atm <$> traverse (armBody %%~ staticArg_expr) arms
+
+staticArg_expr t = pure t
+
+manifestLams :: IsVar a => Type -> Term a -> Int
+manifestLams (ForallTy Relevant{} _ t) (Lam TypeArgument{} b) =
+  1 + manifestLams t b
+manifestLams (ForallTy Irrelevant _ t) (Lam TermArgument{} b) =
+  1 + manifestLams t b
+manifestLams _ _ = 0
+
+{---------------------------------------------------------------------*
+*                    The transformation itself                        *
+*---------------------------------------------------------------------}
+
+doStaticArgs :: forall a m. (IsVar a, MonadNamey m) => a -> Type -> Term a -> m (a, Type, Term a)
+doStaticArgs the_func the_type the_body =
+  if not can_be_done || not worth_it then pure (the_func, the_type, the_body) else do
+    worker <- fromVar . mkVal <$> genNameFrom (func_name <> "_sat")
+    shadow <- mkShadow worker
+    worker_body <- mkWorker shadow
+
+    pure
+      ( the_func
+      , the_type
+      , static_lams $
+          Let (Many [(fromVar worker, worker_ty, worker_body)])
+            (Atom (Ref worker worker_ty))
+        )
+  where
+    func_name = fromMaybe "" (toVar the_func ^. covarName)
+
+    calls = filter ((==) n_lams . length) $ findCalls the_func the_body
+    (binders, innards) = splitLams the_body
+    n_lams = manifestLams the_type the_body
+
+    worker_ty = dropQuantifiers (length static_binders) the_type
+
+    all_binders =
+      map (sconcat . NE.fromList) . transpose . map (flip (zipWith isStatic) binders) $ calls
+
+    static_lams body = foldr mkLam body static_binders where
+      mkLam (Static a) = Lam a
+      mkLam _ = undefined
+
+    non_static_bndrs =
+      map (view _2) . filter ((== NonStatic) . view _1) . zip all_binders $ binders
+
+    static_binders = filter (/= NonStatic) all_binders
+
+    worth_it = length static_binders >= 2
+
+    can_be_done = ok all_binders where
+      ok (Static _:xs) = ok xs
+      ok (NonStatic:xs) = all (== NonStatic) xs
+      ok [] = False
+
+    mkWorker shadow_rhs = do
+      shadow_name <- fromVar . mkVal <$> genNameFrom (func_name <> "_shadow")
+      let bd' = substitute (VarMap.singleton (toVar the_func) shadow_ref) innards
+          bd' :: Term a
+          shadow_ref = Ref (toVar shadow_name) the_type
+
+      let worker_body :: Term a
+          worker_body =
+            Let (One (shadow_name, the_type, shadow_rhs)) bd'
+
+      pure (foldr Lam worker_body non_static_bndrs)
+
+    mkShadow worker =
+      let go_dynamic args = do
+            inside <- mkApps (Ref worker worker_ty) worker_ty args
+            pure $ foldr Lam inside args
+
+          go (Static (TypeArgument _ k):xs) = do
+            x <- fromVar . mkTyvar <$> genName
+            Lam (TypeArgument x k) <$> go xs
+          go (Static (TermArgument _ k):xs) = do
+            x <- fromVar . mkVal <$> genName
+            Lam (TermArgument x k) <$> go xs
+          go [] = go_dynamic non_static_bndrs
+          go _ = error "NonStatic binder in static_binders"
+
+       in go static_binders
+
+isStatic :: IsVar a => Core.Optimise.Arg -> Argument a -> Static (Argument a)
+isStatic (TyArg (VarTy v')) arg@(TypeArgument v _)
+  | toVar v == v' = Static arg
+isStatic (TermArg (Ref v' _)) arg@(TermArgument v _)
+  | toVar v == v' = Static arg
+isStatic _ _ = NonStatic
+
+mkApps :: forall a m. (IsVar a, MonadNamey m) => Atom -> Type -> [Argument a] -> m (Term a)
+mkApps at _ [] = pure $ Atom at
+mkApps at (ForallTy Irrelevant _ t) (TermArgument x tau:xs) = do
+  this_app <- fromVar . mkVal <$> genName
+  Let (One (this_app, t, App at (Ref (toVar x) tau))) <$>
+    mkApps (Ref (toVar this_app) t) t xs
+mkApps at (ForallTy _ _ t) (TypeArgument v _:xs) = do
+  this_app <- fromVar . mkVal <$> genName
+  Let (One (this_app, t, TyApp at (VarTy (toVar v)))) <$>
+    mkApps (Ref (toVar this_app) t) t xs
+mkApps _ xs ys = error $ "Type error in mkApps: " ++ show xs ++ " " ++ show ys
+
+dropQuantifiers :: Int -> Type -> Type
+dropQuantifiers 0 t = t
+dropQuantifiers n (ForallTy _ _ t) = dropQuantifiers (n - 1) t
+dropQuantifiers _ _ = error "type error in dropQuantifiers"
+
+data Static a = Static a | NonStatic
+  deriving (Eq, Show, Ord)
+
+instance Eq a => Semigroup (Static a) where
+  Static x <> Static y
+    | x == y = Static x
+    | otherwise = NonStatic
+  _ <> _ = NonStatic

--- a/src/Core/Optimise/SAT.hs
+++ b/src/Core/Optimise/SAT.hs
@@ -57,6 +57,7 @@ import Core.Optimise
 
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup
+import Data.Maybe
 import Data.List
 
 -- | Do the static argument transformation on a whole program.

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -13,8 +13,9 @@ import Data.Functor
 import Core.Optimise.CommonExpElim
 import Core.Optimise.DeadCode
 import Core.Optimise.Sinking
-import Core.Optimise.Reduce
 import Core.Optimise.Uncurry
+import Core.Optimise.Reduce
+import Core.Optimise.SAT
 import Core.Optimise
 
 import Core.Free
@@ -29,6 +30,7 @@ optmOnce info = passes where
   passes = foldr1 (>=>)
            [ linting "Reduce" reducePass
            , linting' "Dead code" deadCodePass
+           , linting "Static arguments" (const staticArgsPass)
            , linting "Uncurry" (const uncurryPass)
 
            , linting "Sinking" (const (pure . sinkingPass . tagFreeSet))

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -12,15 +12,10 @@ do
   local function _colon_colon(x)
     return function(y) return { { _1 = x, _2 = y }, __tag = "Cons" } end
   end
-  local function _dollarshow(bgb, x)
-    if x.__tag == "Nil" then return "Nil" end
-    local tmp = x[1]
-    return bgb(tmp._1) .. " :: " .. _dollarshow(bgb, tmp._2)
-  end
-  local function _dollartraverse(cak, tmp, k, x)
+  local function _dollartraverse_sat(cak, tmp, k, x)
     if x.__tag == "Nil" then return tmp.pure(Nil) end
     local tmp0 = x[1]
-    return tmp["<*>"](tmp["Applicative$ky"](_colon_colon)(k(tmp0._1)))(_dollartraverse(nil, tmp, k, tmp0._2))
+    return tmp["<*>"](tmp["Applicative$ky"](_colon_colon)(k(tmp0._1)))(_dollartraverse_sat(nil, tmp, k, tmp0._2))
   end
   local function _dollar_d7(cgs, x, ys)
     if x.__tag == "Nil" then return ys end
@@ -28,9 +23,12 @@ do
     return { { _2 = _dollar_d7(nil, tmp._2, ys), _1 = tmp._1 }, __tag = "Cons" }
   end
   local tmp = { _1 = 1, _2 = nil }
-  writeln(_dollarshow(function(x)
-    return _tostring(x)
-  end, _dollartraverse(nil, _dollardApplicativeaou({
+  local function _dollarshow_sat(x)
+    if x.__tag == "Nil" then return "Nil" end
+    local tmp = x[1]
+    return _tostring(tmp._1) .. " :: " .. _dollarshow_sat(tmp._2)
+  end
+  writeln(_dollarshow_sat(_dollartraverse_sat(nil, _dollardApplicativeaou({
     ["×"] = function(x) return function(ys) return _dollar_d7(nil, x, ys) end end,
     zero = Nil
   }), function(tmp0) return { { _1 = tmp0._1, _2 = Nil }, __tag = "Cons" } end, {

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -12,10 +12,10 @@ do
   local function _colon_colon(x)
     return function(y) return { { _1 = x, _2 = y }, __tag = "Cons" } end
   end
-  local function _dollartraverse_sat(cak, tmp, k, x)
+  local function _dollartraverse(cak, tmp, k, x)
     if x.__tag == "Nil" then return tmp.pure(Nil) end
     local tmp0 = x[1]
-    return tmp["<*>"](tmp["Applicative$ky"](_colon_colon)(k(tmp0._1)))(_dollartraverse_sat(nil, tmp, k, tmp0._2))
+    return tmp["<*>"](tmp["Applicative$ky"](_colon_colon)(k(tmp0._1)))(_dollartraverse(nil, tmp, k, tmp0._2))
   end
   local function _dollar_d7(cgs, x, ys)
     if x.__tag == "Nil" then return ys end
@@ -28,7 +28,7 @@ do
     local tmp = x[1]
     return _tostring(tmp._1) .. " :: " .. _dollarshow_sat(tmp._2)
   end
-  writeln(_dollarshow_sat(_dollartraverse_sat(nil, _dollardApplicativeaou({
+  writeln(_dollarshow_sat(_dollartraverse(nil, _dollardApplicativeaou({
     ["×"] = function(x) return function(ys) return _dollar_d7(nil, x, ys) end end,
     zero = Nil
   }), function(tmp0) return { { _1 = tmp0._1, _2 = Nil }, __tag = "Cons" } end, {

--- a/tests/lua/nested_match.lua
+++ b/tests/lua/nested_match.lua
@@ -1,16 +1,20 @@
 do
   local Nil = { __tag = "Nil" }
-  local function zip(f, xs, ys)
-    if xs.__tag == "Nil" then return { { _1 = 1, _2 = Nil }, __tag = "Cons" } end
-    local tmp = xs[1]
-    if ys.__tag == "Nil" then return { { _1 = 2, _2 = Nil }, __tag = "Cons" } end
-    local tmp0, tmp1 = tmp._1, tmp._2
-    local tmp2 = ys[1]
-    local tmp3, tmp4 = tmp2._1, tmp2._2
-    if tmp0 ~= 0 then return { { _1 = f(tmp0)(tmp3), _2 = zip(f, tmp1, tmp4) }, __tag = "Cons" } end
-    if tmp3 == 0 then return { { _1 = 3, _2 = Nil }, __tag = "Cons" } end
-    return { { _1 = f(0)(tmp3), _2 = zip(f, tmp1, tmp4) }, __tag = "Cons" }
+  local function zip(f)
+    local function zip_sat(xs, ys)
+      if xs.__tag == "Nil" then return { { _1 = 1, _2 = Nil }, __tag = "Cons" } end
+      local tmp = xs[1]
+      if ys.__tag == "Nil" then return { { _1 = 2, _2 = Nil }, __tag = "Cons" } end
+      local tmp0, tmp1 = tmp._1, tmp._2
+      local tmp2 = ys[1]
+      local tmp3, tmp4 = tmp2._1, tmp2._2
+      if tmp0 ~= 0 then
+        return { { _1 = f(tmp0)(tmp3), _2 = zip_sat(tmp1, tmp4) }, __tag = "Cons" }
+      end
+      if tmp3 == 0 then return { { _1 = 3, _2 = Nil }, __tag = "Cons" } end
+      return { { _1 = f(0)(tmp3), _2 = zip_sat(tmp1, tmp4) }, __tag = "Cons" }
+    end
+    return function(xs) return function(ys) return zip_sat(xs, ys) end end
   end
-  local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
-  (nil)(zip0)
+  (nil)(zip)
 end

--- a/tests/lua/nested_match_basic.lua
+++ b/tests/lua/nested_match_basic.lua
@@ -1,12 +1,14 @@
 do
   local Nil = { __tag = "Nil" }
-  local function zip(f, xs, ys)
-    if xs.__tag == "Nil" then return { { _1 = 1, _2 = Nil }, __tag = "Cons" } end
-    local tmp = xs[1]
-    if ys.__tag == "Nil" then return { { _1 = 2, _2 = Nil }, __tag = "Cons" } end
-    local tmp0 = ys[1]
-    return { { _1 = f(tmp._1)(tmp0._1), _2 = zip(f, tmp._2, tmp0._2) }, __tag = "Cons" }
+  local function zip(f)
+    local function zip_sat(xs, ys)
+      if xs.__tag == "Nil" then return { { _1 = 1, _2 = Nil }, __tag = "Cons" } end
+      local tmp = xs[1]
+      if ys.__tag == "Nil" then return { { _1 = 2, _2 = Nil }, __tag = "Cons" } end
+      local tmp0 = ys[1]
+      return { { _1 = f(tmp._1)(tmp0._1), _2 = zip_sat(tmp._2, tmp0._2) }, __tag = "Cons" }
+    end
+    return function(xs) return function(ys) return zip_sat(xs, ys) end end
   end
-  local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
-  (nil)(zip0)
+  (nil)(zip)
 end

--- a/tests/lua/opt_sat.lua
+++ b/tests/lua/opt_sat.lua
@@ -1,0 +1,26 @@
+do
+  local Nil = { __tag = "Nil" }
+  local use = print
+  local function map(f)
+    local function map_sat(x)
+      if x.__tag == "Nil" then return Nil end
+      local tmp = x[1]
+      return { { _1 = f(tmp._1), _2 = map_sat(tmp._2) }, __tag = "Cons" }
+    end
+    return map_sat
+  end
+  use(map)
+  local function map_no_sat_sat(f, x)
+    if x.__tag == "Nil" then return Nil end
+    local tmp = x[1]
+    map_no_sat_sat(nil, Nil)
+    local function map_sat(x0)
+      if x0.__tag == "Nil" then return Nil end
+      local tmp0 = x0[1]
+      return { { _1 = (nil)(tmp0._1), _2 = map_sat(tmp0._2) }, __tag = "Cons" }
+    end
+    return { { _1 = (nil)(tmp._1), _2 = map_sat(tmp._2) }, __tag = "Cons" }
+  end
+  local function map_no_sat(f) return function(x) return map_no_sat_sat(f, x) end end
+  use(map_no_sat)
+end

--- a/tests/lua/opt_sat.lua
+++ b/tests/lua/opt_sat.lua
@@ -10,17 +10,12 @@ do
     return map_sat
   end
   use(map)
-  local function map_no_sat_sat(f, x)
+  local function map_no_sat(f, x)
     if x.__tag == "Nil" then return Nil end
     local tmp = x[1]
-    map_no_sat_sat(nil, Nil)
-    local function map_sat(x0)
-      if x0.__tag == "Nil" then return Nil end
-      local tmp0 = x0[1]
-      return { { _1 = (nil)(tmp0._1), _2 = map_sat(tmp0._2) }, __tag = "Cons" }
-    end
-    return { { _1 = (nil)(tmp._1), _2 = map_sat(tmp._2) }, __tag = "Cons" }
+    map_no_sat(nil, Nil)
+    return { { _1 = f(tmp._1), _2 = map(f)(tmp._2) }, __tag = "Cons" }
   end
-  local function map_no_sat(f) return function(x) return map_no_sat_sat(f, x) end end
-  use(map_no_sat)
+  local function map_no_sat0(f) return function(x) return map_no_sat(f, x) end end
+  use(map_no_sat0)
 end

--- a/tests/lua/opt_sat.ml
+++ b/tests/lua/opt_sat.ml
@@ -1,3 +1,17 @@
+external val use : 'a -> () = "print"
+
 let rec map f = function
   | [] -> []
   | Cons (x, xs) -> Cons (f x, map f xs)
+
+let () = use map
+
+external val bottom : 'a = "nil"
+
+let rec map_no_sat f = function
+  | [] -> []
+  | Cons (x, xs) ->
+      let _ = map_no_sat bottom []
+      Cons (f x, map f xs)
+
+let () = use map_no_sat

--- a/tests/lua/opt_sat.ml
+++ b/tests/lua/opt_sat.ml
@@ -1,0 +1,3 @@
+let rec map f = function
+  | [] -> []
+  | Cons (x, xs) -> Cons (f x, map f xs)

--- a/tests/lua/opt_sat_unsat.lua
+++ b/tests/lua/opt_sat_unsat.lua
@@ -1,15 +1,11 @@
 do
   local Nil = { __tag = "Nil" }
-  local function map(f)
-    local function map_sat(x)
-      if x.__tag == "Nil" then return Nil end
-      (function(ji) return function(x) return map_sat(x) end end)(function(x0) return x0 end)({
-        { _1 = 1, _2 = Nil },
-        __tag = "Cons"
-      })
-      local tmp = x[1]
-      return { { _1 = f(tmp._1), _2 = map_sat(tmp._2) }, __tag = "Cons" }
-    end
-    return map_sat
+  local map, map0
+  map = function(f, x)
+    if x.__tag == "Nil" then return Nil end
+    map0(function(x0) return x0 end)({ { _1 = 1, _2 = Nil }, __tag = "Cons" })
+    local tmp = x[1]
+    return { { _1 = f(tmp._1), _2 = map(f, tmp._2) }, __tag = "Cons" }
   end
+  map0 = function(f) return function(x) return map(f, x) end end
 end

--- a/tests/lua/opt_sat_unsat.lua
+++ b/tests/lua/opt_sat_unsat.lua
@@ -1,0 +1,15 @@
+do
+  local Nil = { __tag = "Nil" }
+  local function map(f)
+    local function map_sat(x)
+      if x.__tag == "Nil" then return Nil end
+      (function(ji) return function(x) return map_sat(x) end end)(function(x0) return x0 end)({
+        { _1 = 1, _2 = Nil },
+        __tag = "Cons"
+      })
+      local tmp = x[1]
+      return { { _1 = f(tmp._1), _2 = map_sat(tmp._2) }, __tag = "Cons" }
+    end
+    return map_sat
+  end
+end

--- a/tests/lua/opt_sat_unsat.ml
+++ b/tests/lua/opt_sat_unsat.ml
@@ -1,0 +1,11 @@
+external val opaque_id : 'a -> 'a = "function(x) return x end"
+let id x = x
+
+let rec map : forall 'a 'b. ('a -> 'b) -> list 'a -> list 'b =
+  fun f -> function
+  | [] -> []
+  | Cons (x, xs) -> 
+    let _ = (opaque_id map) id [1] (* Non-saturated usage of map *)
+    Cons (f x, map f xs)
+
+let _ = opaque_id (map @int @int)

--- a/tests/lua/pattern_guard.lua
+++ b/tests/lua/pattern_guard.lua
@@ -1,12 +1,14 @@
 do
   local Nil = { __tag = "Nil" }
-  local function filter(f, x)
-    if x.__tag == "Nil" then return Nil end
-    local tmp = x[1]
-    local x0, xs = tmp._1, tmp._2
-    if f(x0) then return { { _1 = x0, _2 = filter(f, xs) }, __tag = "Cons" } end
-    return filter(f, xs)
+  local function filter(f)
+    local function filter_sat(x)
+      if x.__tag == "Nil" then return Nil end
+      local tmp = x[1]
+      local x0, xs = tmp._1, tmp._2
+      if f(x0) then return { { _1 = x0, _2 = filter_sat(xs) }, __tag = "Cons" } end
+      return filter_sat(xs)
+    end
+    return filter_sat
   end
-  local function filter0(f) return function(x) return filter(f, x) end end
-  (nil)(filter0)
+  (nil)(filter)
 end


### PR DESCRIPTION
The idea of the SAT as an
optimisation is to reduce the number of arguments that must be passed to
a recursive function, and, subsequently, the argument shuffling noise.

Example:

    let map @a @b (f : a -> b) (xs : list a -> list b) =
      match xs with
      | [] -> [] @a
      | Cons (x, xs) ->
        let x = f x
        let xs = map @a @b f xs
        Cons (x, xs)

Here, the recursive call to map is always made with the same arguments
`@a`, `@b`, `f` and `xs`. We call these the "static arguments" of map.
We can lift them out of the recursive path:

    let map @a @b (f : a -> b) =
       let rec map_sat (xs : list a -> list b) =
         let map_shadow @a @b (f : a -> b) (xs : list a -> list b) =
           map_sat xs
         match xs with
         | [] -> [] @a
         | Cons (x, xs) ->
           let x = f x
           let xs = map_shadow @a @b f xs
           Cons (x, xs)
       map_sat

Then, the shadow can inline:

    let map @a @b (f : a -> b) =
       let rec map_sat (xs : list a -> list b) =
         match xs with
         | [] -> [] @a
         | Cons (x, xs) ->
           let x = f x
           let xs = map_sat xs
           Cons (x, xs)
       map_sat

Now the only parameter we have to pass in the recursive loop is 'xs'.
