### PR TITLE
Add :help REPL command with explanations of every command

### DIFF
--- a/bin/Amc/Repl/Command.hs
+++ b/bin/Amc/Repl/Command.hs
@@ -60,6 +60,9 @@ execCommand :: (MonadState ReplState m, MonadIO m) => Listener -> String -> Stri
 execCommand tid "quit"  _   = finish tid
 execCommand tid "q"     _   = finish tid
 
+execCommand _ "h"       _   = helpCommand
+execCommand _ "help"    _   = helpCommand
+
 execCommand _ "l"       arg = loadCommand arg
 execCommand _ "load"    arg = loadCommand arg
 
@@ -94,7 +97,19 @@ execCommand _ "complete" arg = do
     for_ completions $ \(Completion rep _ _) ->
       hPutStrLn out rep
 
-execCommand _ cmd _ = outputDoc ("Unknown command" <+> verbatim cmd)
+execCommand _ cmd _ = outputDoc ("Unknown command" <+> verbatim cmd <+> " Use :h for help.")
+
+helpCommand :: (MonadState ReplState m, MonadIO m) => m ()
+helpCommand =
+  outputDoc "Available commands:\n\
+    \ :q[uit]                 Quit\n\
+    \ :l[oad]    <file>       Import definitions from <file>\n\
+    \ :r[eload]               Reload all loaded modules\n\
+    \ :t[ype]    <expr>       Show the type of <expr>\n\
+    \ :i[nfo]    <var>        Prints the type of <var> as it can be found in the environment\n\
+    \ :c[ompile] <file>       Compiles the current environment to <file>\n\
+    \ :add-library-path <dir> Adds the directory <dir> to the library path\n\
+    \ :complete  <expr>       Shows possible completions for <expr>"
 
 loadCommand :: (MonadState ReplState m, MonadIO m) => String -> m ()
 loadCommand arg =

--- a/tests/amc/prelude.t
+++ b/tests/amc/prelude.t
@@ -2,6 +2,7 @@ Repl will be launched with the prelude
 
   $ echo 'put_line "Hello"' | amc repl
   Listening on port 5478
+  Amulet REPL [0-9.]+ \(\w+\) \:h for available commands(re)
   > _ = ()
   > Hello
 
@@ -9,6 +10,7 @@ Not using the prelude will fail
 
   $ echo 'print "Hello"' | amc repl --no-prelude
   Listening on port 5478
+  Amulet REPL [0-9.]+ \(\w+\) \:h for available commands(re)
   > =stdin[1:1 ..1:5]: error (E1001)
     Variable not in scope: `print`
   
@@ -25,6 +27,7 @@ One can use a custom prelude
 
   $ echo 'print "Hello"' | amc repl --prelude=tests/amc/lib/prelude.ml
   Listening on port 5478
+  Amulet REPL [0-9.]+ \(\w+\) \:h for available commands(re)
   > =stdin:2: Hello
   > 
 
@@ -32,5 +35,6 @@ Prelude is found from the library path
 
   $ echo 'print "Hello"' | amc repl --lib=tests/amc/lib
   Listening on port 5478
+  Amulet REPL [0-9.]+ \(\w+\) \:h for available commands(re)
   > =stdin:2: Hello
   > 


### PR DESCRIPTION
This PR adds a `:help` / `:?` command that displays what each command does.
When starting the REPL, this fact is also displayed.

This would help new users get a hang of the REPL and the available commands.