### PR TITLE
Use stack install to copy binary files

### DIFF
--- a/tools/deploy-build.sh
+++ b/tools/deploy-build.sh
@@ -6,19 +6,12 @@ if [[ $# == 0 ]]; then
   exec $0 amc amc-prove amulet-lsp
 fi
 
-build () {
-  stack build \
-    --ghc-options "-optc-static -optl-static -fhide-source-paths" \
-    --flag amuletml:amc-prove-server $FAST
-}
-
-build
 rm -rfv result/
 mkdir -p result/
 
-for arg in $*; do
-  cp .stack-work/dist/*/"Cabal-3.0.1.0/build/$arg/$arg" result/
-done
+stack install --local-bin-path=result \
+ --ghc-options "-optc-static -optl-static -fhide-source-paths" \
+ --flag amuletml:amc-prove-server $FAST
 
 if which upx &>/dev/null; then
   upx result/*


### PR DESCRIPTION
Intended as a more long-term and less breaky version of 4eeba0c53ca213ac191c3b6f90f6320834a7b92b. This removes any messing around with the `.stack-work` directory, and just makes Stack copy the binaries into the `result/` directory.

While this does mean that UPX will minify all binary files, rather than just ones copied on the command line, I don't think that's a serious problem. That said, should be easy enough to install into a temporary directory and copy from there if preferred.