### PR TITLE
Include the library path on missing imports

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -286,6 +286,7 @@ library
                      -- Main frontend
                      , Frontend.Driver
                      , Frontend.Errors
+                     , Frontend.Files
                      -- the AST
                      , Syntax
                      , Syntax.Let

--- a/bin/Amc.hs
+++ b/bin/Amc.hs
@@ -13,6 +13,7 @@ import Control.Timing
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Traversable
+import Data.Foldable
 import Data.Monoid
 
 import Options.Applicative hiding (ParseError)
@@ -267,10 +268,15 @@ findPrelude (CustomPrelude path) _ = do
 findPrelude DefaultPrelude config = do
   prelude <- D.locatePrelude config
   case prelude of
-    Nothing -> do
+    Left search -> do
       hPutStrLn stderr "Cannot locate prelude. Check your package path, or run using --no-prelude."
+      case search of
+        [] -> hPutStrLn stderr "Library path is empty (is Amulet configured correctly?)"
+        xs -> do
+          hPutStrLn stderr "Searched in"
+          for_ xs (\x -> hPutStrLn stderr (" - " ++ x))
       exitWith (ExitFailure 1)
-    Just prelude -> pure (Just prelude)
+    Right prelude -> pure (Just prelude)
 
 main :: IO ()
 main = do

--- a/src/Frontend/Files.hs
+++ b/src/Frontend/Files.hs
@@ -1,0 +1,46 @@
+-- | Utilities for working with Amulet files or paths
+module Frontend.Files
+  ( findFile'
+  , foldMapM
+  , buildLibraryPath
+  ) where
+
+import System.Environment
+import System.Directory
+import System.FilePath
+
+import qualified Data.Text as T
+import Data.List
+import Data.Foldable
+
+-- | Find the first file which matches a list.
+findFile' :: [FilePath] -> IO (Either [FilePath] FilePath)
+findFile' = go [] where
+  go fs [] = pure . Left $ reverse fs
+  go fs (x:xs) = do
+    path <- canonicalizePath x
+    exists <- doesFileExist path
+    if exists then pure (Right path) else go (path:fs) xs
+
+-- | Akin to 'sequenceA', this maps over a collection, accumulating the
+-- results only if all functions return 'Just'.
+foldMapM :: (Monad m, Foldable t, Monoid b) => (a -> m b) -> t a -> m b
+foldMapM f = foldrM (\a b -> (<>b) <$> f a) mempty
+
+
+-- | Get the defaultlibrary path.
+--
+-- This returns a path which will attempt to locate a file
+-- from one of the "known directories" - $AMC_LIBRARY_PATH,
+-- ../lib/ relative to the compiler's executable, or lib/
+-- relative to the compiler's executable.
+buildLibraryPath :: IO [FilePath]
+buildLibraryPath = do
+  execP <- getExecutablePath
+  path <- foldMap splitColon <$> lookupEnv "AMC_LIBRARY_PATH"
+  pure $ path ++
+    [ takeDirectory execP </> "lib"
+    , takeDirectory (takeDirectory execP) </> "lib"
+    ]
+  where
+    splitColon = nub . map T.unpack . T.split (==':') . T.pack

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -285,8 +285,8 @@ reModule r@(ModImport path a) = do
     ImportCycle loop -> do
       dictates (wrapError r (ImportLoop loop))
       pure (junkVar, Nothing)
-    NotFound -> do
-      dictates (wrapError r (UnresolvedImport path))
+    NotFound search -> do
+      dictates (wrapError r (UnresolvedImport path search))
       pure (junkVar, Nothing)
 
   -- Replace this with a reference so we don't have to care later on

--- a/tests/amc/path.t
+++ b/tests/amc/path.t
@@ -3,11 +3,14 @@ amc compile will extend the compile path
   $ amc compile tests/amc/files/import.ml
   tests/amc/files/import.ml[1:6 ..1:23]: error (E1010)
     Cannot resolve "my_lib.ml"
-  
-    Arising from use of the module
     │ 
   1 │ open import "my_lib.ml"
     │      ^^^^^^^^^^^^^^^^^^
+    
+    Searched in:
+      • .*lib/my_lib.ml(re)
+      • .*lib/my_lib.ml(re)
+      • .*lib/my_lib.ml(re)
   
   The following message has a detailed explanation: 1010.
   Try 'amc explain 1010' to see it.

--- a/tests/resolve/fail_import_abandon.out
+++ b/tests/resolve/fail_import_abandon.out
@@ -1,17 +1,15 @@
 fail_import_abandon.ml[6:8 ..6:30]: error (E1010)
   Cannot resolve "./not_found.ml"
-
-  Arising from use of the module
   │ 
 6 │   open import "./not_found.ml"
   │        ^^^^^^^^^^^^^^^^^^^^^^^
+  
 fail_import_abandon.ml[15:17 ..15:39]: error (E1010)
   Cannot resolve "./not_found.ml"
-
-  Arising from use of the module
    │ 
 15 │ module B = open import "./not_found.ml"
    │                 ^^^^^^^^^^^^^^^^^^^^^^^
+  
 fail_import_abandon.ml[25:12 ..25:22]: error (E1001)
   Variable not in scope: `not_defined`
 

--- a/tests/resolve/fail_import_not_found.out
+++ b/tests/resolve/fail_import_not_found.out
@@ -1,7 +1,6 @@
 fail_import_not_found.ml[1:6 ..1:36]: error (E1010)
   Cannot resolve "./modules/not_found.ml"
-
-  Arising from use of the module
   │ 
 1 │ open import "./modules/not_found.ml"
   │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  

--- a/tests/resolve/fail_import_not_found_path.out
+++ b/tests/resolve/fail_import_not_found_path.out
@@ -1,7 +1,7 @@
 fail_import_not_found_path.ml[1:6 ..1:26]: error (E1010)
   Cannot resolve "not_found.ml"
-
-  Arising from use of the module
   │ 
 1 │ open import "not_found.ml"
   │      ^^^^^^^^^^^^^^^^^^^^^
+  
+  Searched in:


### PR DESCRIPTION
 - Importers now return a "SearchedIn" result, which details where we attempted to load a file from. This is then printed in error messages.

 - Refactor some common library loading code into `Frontend.Driver` from the LSP server and main compiler driver.

Example output:
```
tests/amc/files/import.ml[1:6 ..1:23]: error (E1010)
  Cannot resolve "my_lib.ml"
  │ 
1 │ open import "my_lib.ml"
  │      ^^^^^^^^^^^^^^^^^^
  
  Searched in:
    • /home/squiddev/programming/amulet/lib/my_lib.ml
    • /home/squiddev/programming/amulet/.stack-work/blah/blugh/lib/my_lib.ml
    • /home/squiddev/programming/amulet/.stack-work/blah/lib/my_lib.ml
```