### PR TITLE
Simplify the module importing code

### DIFF
--- a/bin/Amc/Repl/Eval.hs
+++ b/bin/Amc/Repl/Eval.hs
@@ -215,7 +215,7 @@ loadFiles paths = do
       for_ paths $ \path -> do
         (sig, env, lEnv) <- wrapDriver $ do
           ~(Just sig) <- D.getSignature path
-          ~(Just env) <- D.getOpenedTypeEnv path
+          ~(Just env) <- D.getTypeEnv path
           ~(Just lEnv) <- D.getLowerState path
           pure (sig, env, lEnv)
 

--- a/src/Syntax/Builtin.hs
+++ b/src/Syntax/Builtin.hs
@@ -365,11 +365,9 @@ builtinEnv = go builtins where
   go (BM vs ts ms cs ci fi) =
     foldr ((<>) . go . snd) (T.envOf (T.scopeFromList vs <> T.scopeFromList ts)) ms
       & T.types %~ mappend cs
-      & T.modules %~ mappend (fake ms)
       & T.classDecs %~ mappend (Map.fromList ci)
       & T.tySyms %~ mappend (Map.fromList fi)
       & T.classes %~ const builtinInstances
-  fake ms = Map.fromList (ms & map (_2 .~ mempty))
 
 -- | Construct a syntax variable from a core one
 ofCore :: CoVar -> Var Resolved

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -5,7 +5,7 @@ module Syntax.Types
   ( Telescope, one, foldTele, foldTeleM, teleFromList, mapTele, traverseTele, teleToList
   , Scope(..), namesInScope, inScope, scopeToList, mapScope
   , Env, freeInEnv, difference, envOf, scopeFromList, toMap
-  , names, typeVars, constructors, types, letBound, classes, modules
+  , names, typeVars, constructors, types, letBound, classes
   , classDecs, tySyms, declaredHere
   , ClassInfo(..), ciName, ciMethods, ciContext, ciConstructorName, ciAssocTs
   , TySymInfo(..), tsName, tsArgs, tsExpansion, tsKind, TySyms, tsEquations, tsConstraint
@@ -84,7 +84,6 @@ data Env
         , _letBound     :: Set.Set (Var Typed)
         , _declaredHere :: Set.Set (Var Typed) -- Only types
         , _types        :: Map.Map (Var Typed) (Set.Set (Var Typed))
-        , _modules      :: Map.Map (Var Typed) (ImplicitScope ClassInfo Typed, TySyms)
         , _classDecs    :: Map.Map (Var Typed) ClassInfo
         , _tySyms       :: TySyms
         }
@@ -175,21 +174,21 @@ Scope x \\ Scope y = Scope (x Map.\\ y)
 
 instance Monoid Env where
   mappend = (<>)
-  mempty = Env mempty mempty mempty mempty mempty mempty mempty mempty mempty mempty
+  mempty = Env mempty mempty mempty mempty mempty mempty mempty mempty mempty
 
 instance Semigroup Env where
-  Env s i c t d l m n o p <> Env s' i' c' t' d' l' m' n' o' p' =
-    Env (s <> s') (i <> i') (c <> c') (t <> t') (d <> d') (l <> l') (m <> m') (n <> n') (o <> o') (p <> p')
+  Env a b c d e f g h i <> Env a' b' c' d' e' f' g' h' i' =
+    Env (a <> a') (b <> b') (c <> c') (d <> d') (e <> e') (f <> f') (g <> g') (h <> h') (i <> i')
 
 difference :: Env -> Env -> Env
-difference (Env a b c d e f g h i j) (Env a' _ c' d' e' f' g' h' i' j') =
-  Env (a \\ a') b (c Set.\\ c') (d Set.\\ d') (e Set.\\ e') (f Set.\\ f') (g Map.\\ g') (h Map.\\ h') (i Map.\\ i') (j Map.\\ j')
+difference (Env a b c d e f g h i) (Env a' _ c' d' e' f' g' h' i') =
+  Env (a \\ a') b (c Set.\\ c') (d Set.\\ d') (e Set.\\ e') (f Set.\\ f') (g Map.\\ g') (h Map.\\ h') (i Map.\\ i')
 
 freeInEnv :: Env -> Set.Set (Var Typed)
 freeInEnv = foldMap ftv . view names
 
 envOf :: Scope Resolved (Type Typed) -> Env
-envOf a = Env a mempty mempty mempty mempty mempty mempty mempty mempty mempty
+envOf a = Env a mempty mempty mempty mempty mempty mempty mempty mempty
 
 scopeFromList :: OrdPhrase p => [(Var p, f)] -> Scope p f
 scopeFromList = Scope . Map.fromList

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -56,9 +56,9 @@ inferProgram :: MonadNamey m => Env -> [Toplevel Desugared] -> m (These [TypeErr
 inferProgram env ct = fmap fst <$> runInfer env (go ct) where
   go :: MonadInfer Typed m => [Toplevel Desugared] -> m ([Toplevel Typed], Env)
   go ct = do
-    (p, cs) <- listen $ inferProg ct
+    ((p, env), cs) <- listen $ inferProg ct
     _ <- solveFixpoint (It'sThis (BecauseInternal "last round of solving")) (onlyDeferred cs) =<< getSolveInfo
-    pure p
+    pure (p, env & declaredHere .~ mempty)
 
 
 -- | Infer the type of a single expression, including any residual

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -324,8 +324,8 @@ infer (Begin xs a) = do
   pure (Begin (start ++ [end]) (a, t), t)
 
 infer (OpenIn mod expr a) = do
-  (mod', exEnv, (modImplicits, modTysym)) <- inferMod mod
-  local (unqualify mod . exEnv Nothing . (classes %~ (<>modImplicits)) . (tySyms %~ (<>modTysym))) $ do
+  (mod', exEnv) <- inferMod mod
+  local (unqualify mod . exEnv Nothing) $ do
     (expr', ty) <- infer expr
     pure (ExprWrapper (TypeAsc ty) (OpenIn mod' (ExprWrapper (TypeAsc ty) expr' (a, ty)) (a, ty)) (a, ty), ty)
 
@@ -573,29 +573,27 @@ inferProg (DeriveInstance tau ann:prg) = do
     Nothing -> confesses (DICan'tDerive name (BecauseOf inst))
 
 inferProg (Open mod:prg) = do
-  (mod', exEnv, (modImplicits, modTysym)) <- inferMod mod
+  (mod', exEnv) <- inferMod mod
 
-  local (unqualify mod . exEnv Nothing . (classes %~ (<>modImplicits)) . (tySyms %~ (<>modTysym))) $
+  local (unqualify mod . exEnv Nothing) $
     consFst (Open mod') $ inferProg prg
 
 inferProg (Include mod:prg) = do
-  (mod', exEnv, (modImplicits, modTysym)) <- inferMod mod
+  (mod', exEnv) <- inferMod mod
 
-  local (unqualify mod . exEnv Nothing . (classes %~ (<>modImplicits)) . (tySyms %~ (<>modTysym))) $
+  local (unqualify mod . exEnv Nothing) $
     consFst (Include mod') $ inferProg prg
 
 inferProg (Module am name mod:prg) = do
-  (mod', exEnv, modInfo@(modImp, modTS)) <- local (declaredHere .~ mempty) $ inferMod mod
+  (mod', exEnv) <- local (declaredHere .~ mempty) $ inferMod mod
   local (exEnv (Just name)) $
-    local (modules %~ Map.insert name modInfo) $
-      local ((classes %~ (<>modImp)) . (tySyms %~ (<>modTS))) $
-        consFst (Module am name mod') $
-          inferProg prg
+      consFst (Module am name mod') (inferProg prg)
 
 inferProg [] = asks ([],)
 
+-- | Infer a module, returning a typed module and a function for extending the environment.
 inferMod :: MonadInfer Typed m => ModuleTerm Desugared
-         -> m (ModuleTerm Typed, Maybe (Var Resolved) -> Env -> Env, (ImplicitScope ClassInfo Typed, TySyms))
+         -> m (ModuleTerm Typed, Maybe (Var Typed) -> Env -> Env)
 inferMod (ModStruct bod a) = do
   (bod', env) <- inferProg bod
   outside <- view names
@@ -611,17 +609,14 @@ inferMod (ModStruct bod a) = do
          in transformType go
 
   pure (ModStruct bod' a
-       , \prefix ->
-           (names %~ (<> mapScope (append prefix) (qualifyWrt prefix outside) (env ^. names)))
-         . (types %~ (<> (Set.mapMonotonic (append prefix)
-                            <$> Map.mapKeysMonotonic (append prefix) (env ^. types))))
-         . (classDecs %~ (<> (env ^. classDecs)))
-         . (modules %~ (<> Map.mapKeysMonotonic (append prefix) (env ^. modules)))
-       , (env ^. classes, env ^. tySyms))
+       , \prefix extEnv ->
+           let new = env `difference` extEnv
+           in (<>env)
+           . (names %~ (<> mapScope (append prefix) (qualifyWrt prefix outside) (new ^. names)))
+           . (types %~ (<> (Set.mapMonotonic (append prefix) <$> Map.mapKeysMonotonic (append prefix) (new ^. types))))
+           $ extEnv)
 
-inferMod (ModRef name a) = do
-  mod <- view (modules . at name) >>= maybe (confesses (NotInScope name)) pure
-  pure (ModRef name a, const id, mod)
+inferMod (ModRef name a) = pure (ModRef name a, const id)
 
 inferMod ModImport{} = error "Impossible"
 inferMod ModTargetImport{} = error "Impossible"

--- a/src/Types/Infer/App.hs
+++ b/src/Types/Infer/App.hs
@@ -226,7 +226,7 @@ inferQL_ex ex@(Ascription _ t _) = pure <$> liftType (BecauseOf ex) t
 inferQL_ex _ = pure Nothing
 
 -- | Is this type constructor invariant in its arguments?
-invariant :: Map.Map (Var Typed) TySymInfo -> Var Typed -> Bool
+invariant :: TySyms -> Var Typed -> Bool
 invariant syms x =
      x /= tyArrowName       -- The function type is co/contravariant
   && x /= tyTupleName       -- The tuple type is covariant

--- a/src/Types/Infer/Class.hs
+++ b/src/Types/Infer/Class.hs
@@ -50,7 +50,7 @@ import Types.Unify
 
 import GHC.Stack
 
-extendTySyms :: Foldable t => t TySymInfo -> Map.Map VarResolved TySymInfo -> Map.Map VarResolved TySymInfo
+extendTySyms :: Foldable t => t TySymInfo -> TySyms -> TySyms
 extendTySyms syms empty = foldr extend empty syms where
   extend info@(TyFamInfo name eqs _ kind con) = Map.alter go name where
     go Nothing = Just info

--- a/src/Types/Infer/Class.hs-boot
+++ b/src/Types/Infer/Class.hs-boot
@@ -10,7 +10,6 @@ module Types.Infer.Class
 
 import Prelude hiding (lookup)
 
-import qualified Data.Map.Strict as Map
 import Data.Reason
 
 import Control.Monad.Infer
@@ -23,7 +22,7 @@ import Syntax
 
 import GHC.Stack
 
-extendTySyms :: Foldable t => t TySymInfo -> Map.Map VarResolved TySymInfo -> Map.Map VarResolved TySymInfo
+extendTySyms :: Foldable t => t TySymInfo -> TySyms -> TySyms
 
 inferClass :: forall m. MonadInfer Typed m
            => Toplevel Desugared

--- a/src/Types/Infer/Function.hs
+++ b/src/Types/Infer/Function.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, LambdaCase #-}
+{-# LANGUAGE FlexibleContexts, LambdaCase, TypeFamilies #-}
 module Types.Infer.Function
   ( checkValidTypeFunction
   , makeTypeFunctionHIT
@@ -10,7 +10,6 @@ import Control.Monad.Infer
 import Control.Applicative
 import Control.Lens
 
-import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 import Data.Foldable
@@ -60,7 +59,7 @@ familyFree :: MonadInfer Typed m => SomeReason -> Type Typed -> m ()
 familyFree what tau = do
   info <- view tySyms
   let uni = universe tau
-      fam (TyApps (TyCon v ()) _) | Just _ <- Map.lookup v info = True
+      fam (TyApps (TyCon v ()) _) | Just _ <- info ^. at v = True
       fam _ = False
   case find fam uni of
     Just t -> confesses (TyFunInLhs what t)

--- a/tests/types/class/modules.ml
+++ b/tests/types/class/modules.ml
@@ -1,0 +1,10 @@
+class foo 'a
+  val get_foo : 'a
+
+module M =
+  type t = T
+
+  instance foo t
+    let get_foo = T
+
+let M.T = get_foo

--- a/tests/types/class/modules.out
+++ b/tests/types/class/modules.out
@@ -1,0 +1,4 @@
+foo : Req{'a : type}. constraint
+get_foo : Spec{'a : type}. foo 'a => 'a
+M.t : type
+M.T : M.t

--- a/tests/types/letopen.out
+++ b/tests/types/letopen.out
@@ -1,2 +1,2 @@
 Foo.foo : Req{'a : type}. constraint
-Foo.foo_it : Spec{'a : type}. Foo.foo 'a => 'a -> unit
+Foo.foo_it : Spec{'a : type}. Foo.foo 'a => 'a -> Foo.unit

--- a/tests/types/tyfun-scope.ml
+++ b/tests/types/tyfun-scope.ml
@@ -1,0 +1,14 @@
+class idx 'a
+  type key
+  val idx_key : 'a -> key 'a -> ()
+  val idx : 'a -> unit
+
+open
+  type array 'a
+
+  instance idx (array 'a)
+    type key = int
+    let idx_key _ _ = ()
+    let idx _ = ()
+
+let f : array int -> unit = fun x -> idx_key x 0

--- a/tests/types/tyfun-scope.out
+++ b/tests/types/tyfun-scope.out
@@ -1,0 +1,6 @@
+idx : Req{'a : type}. constraint
+key : Req{'a : type}. type
+idx : Spec{'a : type}. idx 'a => 'a -> unit
+idx_key : Spec{'a : type}. idx 'a => 'a -> key 'a -> unit
+array : Infer{'a : type}. 'a -> type
+f : array int -> unit


### PR DESCRIPTION
This removes the notion of a "module scope" within the type checker. Instead of our funky scope extension code, we just do a standard union.

This fixes the following issues:
 - Type classes not being available until the module is opened (#232)
 - Type classes duplicating when opening a module.
 - Type functions not merging equations on opens/imports.