### PR TITLE
Constant folding, again

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -365,6 +365,7 @@ library
                      , Core.Builtin
                      , Core.Optimise
                      , Core.Simplify
+                     , Core.Intrinsic
                      , Core.Occurrence
                      , Core.Optimise.SAT
                      , Core.Optimise.Reduce

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -370,6 +370,7 @@ library
                      , Core.Optimise.SAT
                      , Core.Optimise.Reduce
                      , Core.Optimise.Reduce.Base
+                     , Core.Optimise.Reduce.Fold
                      , Core.Optimise.Reduce.Inline
                      , Core.Optimise.Reduce.Pattern
                      , Core.Optimise.Sinking

--- a/doc/errors.txt
+++ b/doc/errors.txt
@@ -63,3 +63,5 @@ verify/3006.txt Verify: MissingPattern
 verify/3007.txt Verify: MatchToLet
 verify/3008.txt Verify: MatchToFun
 verify/3009.txt Verify: ToplevelRefBinding
+verify/3010.txt Verify: UnknownIntrinsic
+verify/3011.txt Verify: MismatchedIntrinsic

--- a/doc/errors/verify/3010.txt
+++ b/doc/errors/verify/3010.txt
@@ -1,0 +1,15 @@
+Intrinsics are a special kind of foreign declaration which are
+understood by the compiler, meaning they can be optimised or used
+to generate efficient code.
+
+Intrinsics are declared with a foreign declaration, whose body starts
+with '%'. For instance:
+
+    external val ( + ) : int -> int -> int = "%int.add"
+
+If you see this error, this means you are using an intrinsic which
+doesn't exist. The compiler will not understand it, and just treat it
+as a normal external declaration.
+
+Intrinsics normally have the form "%<type>.<operation>".  Make sure
+you've spelled everything correctly, and there's no trailing spaces!

--- a/doc/errors/verify/3011.txt
+++ b/doc/errors/verify/3011.txt
@@ -1,0 +1,15 @@
+Intrinsics are a special kind of foreign declaration which are
+understood by the compiler, meaning they can be optimised or used
+to generate efficient code.
+
+Intrinsics are declared with a foreign declaration, whose body starts
+with '%'. For instance:
+
+    external val ( + ) : int -> int -> int = "%int.add"
+
+However, when declaring an intrinsic, the types must match up exactly
+with what compiler expects. For instance, the integer add operation
+shouldn't accept two floats instead!
+
+In order to fix this, it should just be a matter of replacing the
+declaration's type with the correct one.

--- a/lib/amulet/base/intrinsics.ml
+++ b/lib/amulet/base/intrinsics.ml
@@ -1,0 +1,28 @@
+module Public = struct
+  external val ( + )  : int -> int -> int   = "%int.add"
+  external val ( * )  : int -> int -> int   = "%int.mul"
+  external val ( - )  : int -> int -> int   = "%int.sub"
+  external val ( ** ) : int -> int -> int   = "%int.pow"
+  external val ( / )  : int -> int -> float = "%int.div"
+
+  external val ( +. )  : float -> float -> float = "%float.add"
+  external val ( *. )  : float -> float -> float = "%float.mul"
+  external val ( -. )  : float -> float -> float = "%float.sub"
+  external val ( **. ) : float -> float -> float = "%float.pow"
+  external val ( /. )  : float -> float -> float = "%float.div"
+
+  external val (^) : string -> string -> string = "%string.concat"
+
+  external val (<.)  : float -> float -> bool = "%float.lt"
+  external val (<=.) : float -> float -> bool = "%float.le"
+end
+
+external val int_eq    : int -> int -> bool       = "%int.eq"
+external val float_eq  : float -> float -> bool   = "%float.eq"
+external val string_eq : string -> string -> bool = "%string.eq"
+
+external val lt_int  : int -> int -> bool = "%int.lt"
+external val lte_int : int -> int -> bool = "%int.le"
+
+external val lt_string  : string -> string -> bool = "%string.lt"
+external val lte_string : string -> string -> bool = "%string.le"

--- a/lib/amulet/base/lua.ml
+++ b/lib/amulet/base/lua.ml
@@ -1,36 +1,17 @@
+private module Intrinsics = import "./intrinsics.ml"
+
+include Intrinsics
+
 module Public = struct
-  external val ( + )  : int -> int -> int   = "function (x, y) return x + y end"
-  external val ( * )  : int -> int -> int   = "function (x, y) return x * y end"
-  external val ( - )  : int -> int -> int   = "function (x, y) return x - y end"
-  external val ( ** ) : int -> int -> int   = "function (x, y) return x ^ y end"
-  external val ( / )  : int -> int -> float = "function (x, y) return x / y end"
+  include Public
 
-  external val ( +. )  : float -> float -> float = "function (x, y) return x + y end"
-  external val ( *. )  : float -> float -> float = "function (x, y) return x * y end"
-  external val ( -. )  : float -> float -> float = "function (x, y) return x - y end"
-  external val ( **. ) : float -> float -> float = "function (x, y) return x ^ y end"
-  external val ( /. )  : float -> float -> float = "function (x, y) return x / y end"
-
-  external val (^) : string -> string -> string = "function(x, y) return x .. y end"
-
-  external val (<.)  : float -> float -> bool = "function (x, y) return x < y end"
-  external val (<=.) : float -> float -> bool = "function (x, y) return x <= y end"
   external val (>.)  : float -> float -> bool = "function (x, y) return x > y end"
   external val (>=.) : float -> float -> bool = "function (x, y) return x >= y end"
 end
-
-external val int_eq    : int -> int -> bool       = "function(x, y) return x == y end"
-external val float_eq  : float -> float -> bool   = "function(x, y) return x == y end"
-external val string_eq : string -> string -> bool = "function(x, y) return x == y end"
-
-external val lt_int : int -> int -> bool = "function (x, y) return x < y end"
-external val lte_int : int -> int -> bool = "function (x, y) return x <= y end"
-external val gt_int : int -> int -> bool = "function (x, y) return x > y end"
+external val gt_int  : int -> int -> bool = "function (x, y) return x > y end"
 external val gte_int : int -> int -> bool = "function (x, y) return x >= y end"
 
-external val lt_string : string -> string -> bool = "function (x, y) return x < y end"
-external val lte_string : string -> string -> bool = "function (x, y) return x <= y end"
-external val gt_string : string -> string -> bool = "function (x, y) return x > y end"
+external val gt_string  : string -> string -> bool = "function (x, y) return x > y end"
 external val gte_string : string -> string -> bool = "function (x, y) return x >= y end"
 
 external val string_of_int : int -> string = "tostring"

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -581,9 +581,9 @@ emitStmt :: forall a m. (Occurs a, MonadState TopEmitState m)
          => [AnnStmt VarSet.Set a] -> m (Seq LuaStmt)
 emitStmt [] = pure mempty
 
-emitStmt (Foreign n t (Intrinsic i):xs) = do
+emitStmt (Foreign n t f@(Intrinsic i):xs) = do
   n' <- pushTopScope n
-  topArity %= flip extendForeign (n, t)
+  topArity %= extendForeign (n, t) f
 
   -- We've got an expression which can be inlined, push a 'VarInline'!
   let op = opOfIntrinsic i
@@ -599,9 +599,9 @@ emitStmt (Foreign n t (Intrinsic i):xs) = do
 
   emitStmt xs
 
-emitStmt (Foreign n t (ForeignCode s):xs) = do
+emitStmt (Foreign n t f@(ForeignCode s):xs) = do
   n' <- pushTopScope n
-  topArity %= flip extendForeign (n, t)
+  topArity %= extendForeign (n, t) f
 
   let ex = case parseExpr (SourcePos "_" 0 0) (s ^. lazy) of
         Right x -> x

--- a/src/Core/Arity.hs
+++ b/src/Core/Arity.hs
@@ -116,12 +116,17 @@ extendPureCtors s cts = s {
     typeArity (ForallTy _ _ ty) = 1 + typeArity ty
     typeArity _ = 0
 
-extendForeign :: IsVar a => ArityScope -> (a, Type) -> ArityScope
-extendForeign (ArityScope scope) (var, ty) =
-  ArityScope (VarMap.insert (toVar var) (Arity (typeArity ty) False) scope)
-  where typeArity :: Type -> Int
-        typeArity (ForallTy _ _ ty) = 1 + typeArity ty
-        typeArity _ = 0
+extendForeign :: IsVar a => (a, Type) -> Foreign -> ArityScope -> ArityScope
+extendForeign (var, ty) f (ArityScope scope) =
+  ArityScope (VarMap.insert (toVar var) (Arity (typeArity ty) isPure ) scope)
+  where
+    typeArity :: Type -> Int
+    typeArity (ForallTy _ _ ty) = 1 + typeArity ty
+    typeArity _ = 0
+
+    isPure = case f of
+      Intrinsic _ -> True
+      ForeignCode _ -> False
 
 mapArity :: (Int -> Int) -> Arity -> Arity
 mapArity f (Arity a p) = Arity (f a) p

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -14,6 +14,8 @@ import Data.Triple
 import Data.Maybe
 import Data.Text (Text)
 import Data.List
+
+import Core.Intrinsic
 import Core.Var
 
 import Data.Typeable (Typeable)
@@ -182,8 +184,13 @@ pattern ExactRowsTy ts = RowsTy NilTy ts
 data BoundTv = Irrelevant | Relevant CoVar
   deriving (Eq, Show, Ord, Generic, Hashable)
 
+data Foreign
+  = Intrinsic Intrinsic
+  | ForeignCode Text
+  deriving (Eq, Show, Ord, Generic, Hashable)
+
 data AnnStmt b a
-  = Foreign a Type Text
+  = Foreign a Type Foreign
   | StmtLet (AnnBinding b a)
   | Type a [(a, Type)]
   deriving (Eq, Show, Ord, Functor, Generic, Hashable)

--- a/src/Core/Intrinsic.hs
+++ b/src/Core/Intrinsic.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+module Core.Intrinsic
+  ( Intrinsic(..)
+  , intrinsicOf
+  ) where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import Data.Hashable
+import Data.Maybe
+import Data.Tuple
+
+import GHC.Generics
+
+data Intrinsic
+  = IntAdd
+  | IntSub
+  | IntMul
+  | IntDiv
+  | IntPow
+  | IntEq
+  | IntLt
+  | IntLe
+
+  | FloatAdd
+  | FloatSub
+  | FloatMul
+  | FloatDiv
+  | FloatPow
+  | FloatEq
+  | FloatLt
+  | FloatLe
+
+  | StrConcat
+  | StrEq
+  | StrLt
+  | StrLe
+  deriving (Eq, Ord, Generic, Hashable)
+
+names :: [(String, Intrinsic)]
+names =
+  [ ( "int.add", IntAdd )
+  , ( "int.sub", IntSub )
+  , ( "int.mul", IntMul )
+  , ( "int.div", IntDiv )
+  , ( "int.pow", IntPow )
+  , ( "int.eq", IntEq )
+  , ( "int.lt", IntLt )
+  , ( "int.le", IntLe )
+
+  , ( "float.add", FloatAdd )
+  , ( "float.sub", FloatSub )
+  , ( "float.mul", FloatMul )
+  , ( "float.div", FloatDiv )
+  , ( "float.pow", FloatPow )
+  , ( "float.eq", FloatEq )
+  , ( "float.lt", FloatLt )
+  , ( "float.le", FloatLe )
+
+  , ( "string.concat", StrConcat )
+  , ( "string.eq", StrEq )
+  , ( "string.lt", StrLt )
+  , ( "string.le", StrLe )
+  ]
+
+instance Show Intrinsic where
+  show = fromJust . flip Map.lookup (Map.fromList . map swap $ names)
+
+intrinsicOf :: T.Text -> Maybe Intrinsic
+intrinsicOf = go where
+  go t
+    | Just ('%', x) <- T.uncons t = Map.lookup (T.unpack x) lookup
+    | otherwise = Nothing
+
+  lookup = Map.fromList names

--- a/src/Core/Optimise/CommonExpElim.hs
+++ b/src/Core/Optimise/CommonExpElim.hs
@@ -17,8 +17,8 @@ type CseScope a = HashMap (Term a) a
 csePass :: forall a. IsVar a => [Stmt a] -> [Stmt a]
 csePass = cseStmt emptyScope where
   cseStmt :: ArityScope -> [Stmt a] -> [Stmt a]
-  cseStmt scope (x@(Foreign v ty _):xs) =
-    let scope' = extendForeign scope (v, ty)
+  cseStmt scope (x@(Foreign v ty f):xs) =
+    let scope' = extendForeign (v, ty) f scope
      in x:cseStmt scope' xs
   cseStmt scope (StmtLet (One b@(v, ty, ex)):xs) =
     let s' = extendPureLets scope [b]

--- a/src/Core/Optimise/DeadCode.hs
+++ b/src/Core/Optimise/DeadCode.hs
@@ -34,8 +34,8 @@ deadCodePass info = snd . freeS emptyScope where
   freeS :: IsVar a => ArityScope -> [Stmt a] -> (VarSet.Set, [Stmt a])
   freeS _ [] = (exportNames info, mempty)
 
-  freeS s (x@(Foreign v ty _):xs) =
-    let s' = extendForeign s (v, ty)
+  freeS s (x@(Foreign v ty f):xs) =
+    let s' = extendForeign (v, ty) f s
         (fxs, xs') = freeS s' xs
      in if toVar v `VarSet.member` fxs
            then (toVar v `VarSet.delete` fxs, x:xs')

--- a/src/Core/Optimise/Reduce/Fold.hs
+++ b/src/Core/Optimise/Reduce/Fold.hs
@@ -77,7 +77,9 @@ float :: Double -> Maybe (Term a)
 float = atom . Lit . Float
 
 bool :: Bool -> Maybe (Term a)
-bool x = atom (Lit (if x then LitTrue else LitFalse))
+bool x = 
+  let val = if x then LitTrue else LitFalse
+  in val `seq` atom (Lit val)
 
 atom :: Atom -> Maybe (Term a)
 atom = Just . Atom

--- a/src/Core/Optimise/Reduce/Fold.hs
+++ b/src/Core/Optimise/Reduce/Fold.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+module Core.Optimise.Reduce.Fold
+  ( foldApply
+  ) where
+
+import qualified Data.Text as T
+
+import Core.Optimise.Reduce.Base
+import Core.Intrinsic
+
+-- | Apply constant folding an application of some arbitrary function.
+--
+-- Note the function provided must be the "raw" variant (not applied to
+-- any types).
+foldApply :: Intrinsic -> [Atom] -> Maybe (Term a)
+foldApply i [Lit l, Lit r] = foldLiteral i [l, r]
+
+-- Partial integer reductions
+foldApply IntAdd [x, Lit (Int 0)] = atom x
+foldApply IntAdd [Lit (Int 0), x] = atom x
+foldApply IntSub [x, Lit (Int 0)] = atom x
+foldApply IntMul [x, Lit (Int 1)] = atom x
+foldApply IntMul [Lit (Int 1), x] = atom x
+foldApply IntMul [_, Lit (Int 0)] = int 0
+foldApply IntMul [Lit (Int 0), _] = int 0
+foldApply IntDiv [x, Lit (Int 1)] = atom x
+foldApply IntEq  [Ref l _, Ref r _] | l == r = bool True
+
+-- We don't apply similar reductions for floats. Given the presence of
+-- NaN, most folds aren't safe.
+
+-- Partial string reductions
+foldApply StrConcat [x, Lit (Str "")] = atom x
+foldApply StrConcat [Lit (Str ""), x] = atom x
+foldApply StrEq     [Ref l _, Ref r _] | l == r = bool True
+
+foldApply _ _ = Nothing
+
+-- | Attempt to fold an application to a builtin function with a series
+-- of literal values.
+foldLiteral :: Intrinsic -> [Literal] -> Maybe (Term a)
+
+-- Integer reductions
+foldLiteral IntAdd [Int l, Int r] = int (l + r)
+foldLiteral IntSub [Int l, Int r] = int (l - r)
+foldLiteral IntMul [Int l, Int r] = int (l * r)
+foldLiteral IntDiv [Int l, Int r] = float (fromIntegral l / fromIntegral r)
+foldLiteral IntPow [Int l, Int r] = int (l ^ r)
+foldLiteral IntEq  [Int l, Int r] = bool (l == r)
+foldLiteral IntLt  [Int l, Int r] = bool (l < r)
+foldLiteral IntLe  [Int l, Int r] = bool (l <= r)
+
+foldLiteral FloatAdd [Float l, Float r] = float (l + r)
+foldLiteral FloatSub [Float l, Float r] = float (l - r)
+foldLiteral FloatMul [Float l, Float r] = float (l * r)
+foldLiteral FloatDiv [Float l, Float r] = float (l / r)
+foldLiteral FloatPow [Float l, Float r] = float (l ** r)
+foldLiteral FloatEq  [Float l, Float r] = bool (l == r)
+foldLiteral FloatLt  [Float l, Float r] = bool (l < r)
+foldLiteral FloatLe  [Float l, Float r] = bool (l <= r)
+
+-- String reductions
+foldLiteral StrConcat [Str l, Str r] = str (l `T.append` r)
+foldLiteral StrEq     [Str l, Str r] = bool (l == r)
+foldLiteral StrLt     [Str l, Str r] = bool (l < r)
+foldLiteral StrLe     [Str l, Str r] = bool (l <= r)
+
+foldLiteral _ _ = Nothing
+
+int :: Integer -> Maybe (Term a)
+int = atom . Lit . Int
+
+str :: T.Text -> Maybe (Term a)
+str = atom . Lit . Str
+
+float :: Double -> Maybe (Term a)
+float = atom . Lit . Float
+
+bool :: Bool -> Maybe (Term a)
+bool x = atom (Lit (if x then LitTrue else LitFalse))
+
+atom :: Atom -> Maybe (Term a)
+atom = Just . Atom

--- a/src/Core/Optimise/Reduce/Inline.hs
+++ b/src/Core/Optimise/Reduce/Inline.hs
@@ -303,7 +303,7 @@ gatherInlining (AnnApp _ (Ref f _) x) = do
     _ -> do
       s <- asks (lookupVar (toVar f))
       pure $ case s of
-        VarDef { varDef = Just DefInfo { defTerm = Lam (TermArgument v _) bod }
+        VarDef { varDef = DefInfo { defTerm = Lam (TermArgument v _) bod }
                , varLoopBreak = False }
           -> Just ( Right ([(v, x)], mempty, bod)
                   , mempty )
@@ -324,7 +324,7 @@ gatherInlining (AnnTyApp _ (Ref f _) x) = do
     _ -> do
       s <- asks (lookupVar (toVar f))
       pure $ case s of
-        VarDef { varDef = Just DefInfo { defTerm = Lam (TypeArgument v _) bod }
+        VarDef { varDef = DefInfo { defTerm = Lam (TypeArgument v _) bod }
                , varLoopBreak = False }
           -> Just (Right (mempty, [(v, x)], bod), mempty)
         _ -> Nothing

--- a/src/Core/Optimise/Sinking.hs
+++ b/src/Core/Optimise/Sinking.hs
@@ -48,7 +48,7 @@ sinkingPass = sinkStmts (SinkState [] A.emptyScope)
 sinkStmts :: IsVar a => SinkState a -> [AnnStmt VarSet.Set a] -> [Stmt a]
 sinkStmts _ [] = []
 sinkStmts s (Foreign v ty bod:xs) =
-  let s' = s { arity = A.extendForeign (arity s) (v, ty) }
+  let s' = s { arity = A.extendForeign (v, ty) bod (arity s) }
    in Foreign v ty bod:sinkStmts s' xs
 sinkStmts s (StmtLet (One v):xs) =
   let v' = third3 (sinkTerm s) v

--- a/tests/lua/opt_constant_fold.lua
+++ b/tests/lua/opt_constant_fold.lua
@@ -1,0 +1,40 @@
+do
+  local ignore = function(x)  end
+  ignore(function(tmp)
+    local i, s = tmp.i, tmp.s
+    return {
+      int_add_c = 5,
+      int_sub_c = -1,
+      int_mul_c = 6,
+      int_div_c = 3.0,
+      int_exp_c = 8,
+      int_eq_c = false,
+      int_lt_c = true,
+      int_le_c = true,
+      int_add_l = i,
+      int_add_r = i,
+      int_sub_l = i,
+      int_mul1_l = i,
+      int_mul1_r = i,
+      int_mul_l = 0,
+      int_mul_r = 0,
+      int_div_l = i,
+      float_add_c = 5.0,
+      float_sub_c = -1.0,
+      float_mul_c = 6.0,
+      float_div_c = 3.0,
+      float_exp_c = 8.0,
+      float_eq_c = false,
+      float_lt_c = true,
+      float_le_c = true,
+      str_con_c = "foobar",
+      str_eq_c = false,
+      str_le_c = false,
+      str_lt_c = false,
+      str_con_l = s,
+      str_con_r = s,
+      int_eq_u = true,
+      str_eq_u = true
+    }
+  end)
+end

--- a/tests/lua/opt_constant_fold.ml
+++ b/tests/lua/opt_constant_fold.ml
@@ -1,0 +1,65 @@
+external val ignore : 'a -> () = "function(x) end"
+
+external val ( +  ) : int -> int -> int = "%int.add"
+external val ( -  ) : int -> int -> int = "%int.sub"
+external val ( *  ) : int -> int -> int = "%int.mul"
+external val ( ** ) : int -> int -> int = "%int.pow"
+external val ( /  ) : int -> int -> int = "%int.div"
+external val ( == ) : int -> int -> bool = "%int.eq"
+external val ( <= ) : int -> int -> bool = "%int.le"
+external val ( <  ) : int -> int -> bool = "%int.lt"
+
+external val ( +.  ) : float -> float -> float = "%float.add"
+external val ( -.  ) : float -> float -> float = "%float.sub"
+external val ( *.  ) : float -> float -> float = "%float.mul"
+external val ( **. ) : float -> float -> float = "%float.pow"
+external val ( /.  ) : float -> float -> float = "%float.div"
+external val ( ==. ) : float -> float -> bool = "%float.eq"
+external val ( <=. ) : float -> float -> bool = "%float.le"
+external val ( <.  ) : float -> float -> bool = "%float.lt"
+
+external val ( ^ ) : string -> string -> bool = "%string.concat"
+external val ( ==? ) : string -> string -> bool = "%string.eq"
+external val ( <=? ) : string -> string -> bool = "%string.le"
+external val ( <?  ) : string -> string -> bool = "%string.lt"
+
+
+let () = ignore (fun { i, s }->
+  { int_add_c = 2 + 3
+  , int_sub_c = 2 - 3
+  , int_mul_c = 2 * 3
+  , int_div_c = 6 / 2
+  , int_exp_c = 2 ** 3
+  , int_eq_c  = 2 == 3
+  , int_lt_c  = 2 < 3
+  , int_le_c  = 2 <= 3
+
+  , int_add_l = i + 0
+  , int_add_r = 0 + i
+  , int_sub_l = i - 0
+  , int_mul1_l = i * 1
+  , int_mul1_r = 1 * i
+  , int_mul_l = i * 0
+  , int_mul_r = 0 * i
+  , int_div_l = i / 1
+
+  , float_add_c = 2.0 +. 3.0
+  , float_sub_c = 2.0 -. 3.0
+  , float_mul_c = 2.0 *. 3.0
+  , float_div_c = 6.0 /. 2.0
+  , float_exp_c = 2.0 **. 3.0
+  , float_eq_c  = 2.0 ==. 3.0
+  , float_lt_c  = 2.0 <. 3.0
+  , float_le_c  = 2.0 <=. 3.0
+
+  , str_con_c = "foo" ^ "bar"
+  , str_eq_c = "foo" ==? "bar"
+  , str_le_c = "foo" <=? "bar"
+  , str_lt_c = "foo" <? "bar"
+
+  , str_con_l = s ^ ""
+  , str_con_r = "" ^ s
+
+  , int_eq_u = i == i
+  , str_eq_u = s ==? s
+  })

--- a/tests/verify/intrinsic.ml
+++ b/tests/verify/intrinsic.ml
@@ -1,0 +1,3 @@
+external val add : int -> int -> int = "%int.adds"
+
+external val add' : int -> int -> bool = "%int.add"

--- a/tests/verify/intrinsic.out
+++ b/tests/verify/intrinsic.out
@@ -1,0 +1,13 @@
+intrinsic.ml[1:1 ..1:50]: warning (W3010)
+  Unknown intrinsic 'int.adds'
+  │ 
+1 │ external val add : int -> int -> int = "%int.adds"
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+intrinsic.ml[3:1 ..3:51]: error (E3011)
+  Mismatched type for intrinsic 'int.add'. Definition has type
+    int -> int -> bool
+  but should have type
+    int -> int -> int
+  │ 
+3 │ external val add' : int -> int -> bool = "%int.add"
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
 - Add support for "intrinsics" (see #205) to Core. These are just written as foreign bindings, prefixed with a `%` (e.g. `external val ( + ) : int -> int -> int = "%int.add"`).
 - Verify checks intrinsics exist and have the correct type.
 - Adds back the constant folding pass removed in #184.

